### PR TITLE
[#3]feat:카테고리 항목 추가(#31)

### DIFF
--- a/SYKim_Doc/api_mapper_payload_matrix.md
+++ b/SYKim_Doc/api_mapper_payload_matrix.md
@@ -5,8 +5,8 @@
 
 | API | 최종 DTO | 프론트 수신 필드 (Mapper 조립 포함) |
 |-----|---------|--------------------------------|
-| `GET /api/notes/published/today-cover` | `NoteCoverResponse` | `title`, `teaser`, `mainImageUrl`, `creatorName`, `creatorJobTitle`, `publishedDate` |
-| `GET /api/notes/published/today-preview` | `NotePreviewResponse` | `id`, `cover { title, mainImageUrl, creatorName, creatorJobTitle, publishedDate } (teaser=null)`, `overview { sectionTitle, bodyText(<=100자), imageUrl }` |
+| `GET /api/notes/published/today-cover` | `NoteCoverResponse` | `title`, `teaser`, `mainImageUrl`, `creatorName`, `creatorJobTitle`, `publishedDate` *(카테고리 배지는 미노출)* |
+| `GET /api/notes/published/today-preview` | `NotePreviewResponse` | `id`, `cover { title, mainImageUrl, creatorName, creatorJobTitle, publishedDate, categoryBadge? } (teaser=null)`, `overview { sectionTitle, bodyText(<=100자), imageUrl }` |
 | `GET /api/notes/published/today-detail` | `TodayPublishedResponse` | `accessible`, `note`(`NoteResponse` 전체), `preview`(`NotePreviewResponse`) |
 | `GET /api/notes/archived` | `Page<ArchivedNoteSummaryResponse>` | 항목별 `id`, `tagText`, `title`, `mainImageUrl`, `creatorName`, `publishedDate` |
 | `GET /api/notes/archived/{id}` | `ArchivedNoteViewResponse` | `accessible`, `note?`(`NoteResponse` 전체), `preview?`(`NotePreviewResponse` 전체) |
@@ -20,7 +20,7 @@
 
 ### NoteResponse 전체 필드
 - `id`, `status`, `tagText`
-- `cover { title, teaser(2.1 한정), mainImageUrl, creatorName, creatorJobTitle, publishedDate }`
+- `cover { title, teaser(2.1 한정), mainImageUrl, creatorName, creatorJobTitle, publishedDate, categoryBadge? }`
 - `overview { sectionTitle, bodyText, imageUrl }`
 - `retrospect { sectionTitle, bodyText }`
 - `processes[] { position, sectionTitle, bodyText, imageUrl }`
@@ -33,7 +33,7 @@
 
 ### NotePreviewResponse 전체 필드
 - `id`
-- `cover { title, mainImageUrl, creatorName, creatorJobTitle, publishedDate } (teaser=null)`
+- `cover { title, mainImageUrl, creatorName, creatorJobTitle, publishedDate, categoryBadge? } (teaser=null)`
 - `overview { sectionTitle, bodyText(<=100자), imageUrl }`
 
 ### ArchivedNoteSummaryResponse
@@ -44,5 +44,7 @@
 
 ## 참고 사항
 - `NoteCoverDto`의 `creatorName/creatorJobTitle`은 **요청 시 optional**이며 Admin UI 프리뷰 용도. 서버 저장은 `creatorId`로만 처리하지만, 응답 시 매퍼가 `Creator` 엔티티에서 값을 다시 채운다.
+- `cover.categoryBadge`는 today-preview/today-detail에서만 내려오며, 다른 API에서는 `null`.
+- `categoryBadge.type`는 `NoteCategoryType` enum(`MURAL`, `EMOTICON`, `GRAPHIC`, `PRODUCT`, `FASHION`, `THREE_D`, `BRANDING`, `ILLUSTRATION`, `MEDIA_ART`, `FURNITURE`, `THEATER_SIGN`, `LANDSCAPE`, `ALBUM_ARTWORK`, `VISUAL_DIRECTING`, `NONE`) 중 하나다.
 - `ArchivedNoteViewResponse`는 `accessible` 플래그로 프론트가 단일 API 결과를 분기할 수 있도록 설계했다.
 - Bookmark 검색은 `NoteBookmarkRepository.searchByUserIdAndKeyword` → `NoteMapper.toBookmarkResponse` → Controller에서 `BookmarkListItemResponse`로 변환한다.

--- a/SYKim_Doc/feature_notes_frontend_plan.md
+++ b/SYKim_Doc/feature_notes_frontend_plan.md
@@ -58,16 +58,30 @@ export interface NoteProcessDto {
   imageUrl: string;
 }
 
+export type NoteCategoryType = 'FREE' | 'PREMIUM' | 'GENERAL';
+
+export interface CategoryBadgeResponse {
+  type: NoteCategoryType;
+  label: string;
+}
+
 export interface NoteCoverDto {
   title: string;
   teaser: string;
   mainImageUrl: string;
   creatorName?: string;
   creatorJobTitle?: string;
+  category?: NoteCategoryType;
 }
 
-export interface NoteCoverResponse extends NoteCoverDto {
+export interface NoteCoverResponse {
+  title: string;
+  teaser?: string;
+  mainImageUrl: string;
+  creatorName?: string;
+  creatorJobTitle?: string;
   publishedDate?: string;
+  categoryBadge?: CategoryBadgeResponse;
 }
 
 export interface NoteOverviewDto {

--- a/SYKim_Doc/frontend_payload_review.md
+++ b/SYKim_Doc/frontend_payload_review.md
@@ -25,6 +25,7 @@ flowchart LR
   - `mainImageUrl`
   - `creatorName?`
   - `creatorJobTitle?`
+  - `category?` (`MURAL`, `EMOTICON`, `GRAPHIC`, `PRODUCT`, `FASHION`, `THREE_D`, `BRANDING`, `ILLUSTRATION`, `MEDIA_ART`, `FURNITURE`, `THEATER_SIGN`, `LANDSCAPE`, `ALBUM_ARTWORK`, `VISUAL_DIRECTING`, `NONE` 중 택 1)
 - `overview` / `retrospect` / `processes(2개)` / `question`
 - `creatorId` *(필수)*
 - `externalLink` *(선택)*
@@ -62,7 +63,8 @@ sequenceDiagram
 - `id`, `status`, `tagText`
 - `cover: NoteCoverResponse`
   - `title`, `teaser`, `mainImageUrl`, `creatorName`, `creatorJobTitle`, `publishedDate`
-  - `NoteCoverDto`에도 동일 필드 존재하여 생성/수정 시 재사용
+  - `categoryBadge?` (오늘 상세/미리보기에서만 내려오며, 다른 API에서는 `null`)
+  - `NoteCoverDto`에도 동일 base 필드 + `category` 존재하여 생성/수정 시 재사용
 - `overview`, `retrospect`, `processes(2)`, `question`, `answer`
 - `creatorId`, `creatorJobTitle` *(매퍼에서 Creator 정보 추출)*
 - `externalLink`, `creator`(Summary)
@@ -153,7 +155,7 @@ sequenceDiagram
 | API/기능 | 프론트 전달 DTO | 핵심 필드 |
 |----------|----------------|-----------|
 | `POST /api/admin/notes` | `NoteCreateRequest` | status, tagText, cover(title/teaser/mainImageUrl/creatorName?/creatorJobTitle?), overview, retrospect, processes(2), question, creatorId, externalLink |
-| `GET /api/notes/published/today-detail` | `TodayPublishedResponse` → `NoteResponse`/`NotePreviewResponse` | NoteResponse 전체 필드(cover 포함), preview는 커버 + overview(본문 100자) |
+| `GET /api/notes/published/today-detail` | `TodayPublishedResponse` → `NoteResponse`/`NotePreviewResponse` | NoteResponse 전체 필드(cover + `categoryBadge?`), preview는 커버 + overview(본문 100자, `categoryBadge?`) |
 | `GET /api/notes/archived/{id}` | `ArchivedNoteViewResponse` | `accessible` flag에 따라 `NoteResponse` 또는 `NotePreviewResponse` |
 | `GET /api/notes/bookmarks?keyword` | `BookmarkListItemResponse[]` | noteId, title, mainImageUrl, creatorName, tagText (검색 결과 강조용) |
 

--- a/SYKim_Doc/note_mapper_frontend_payloads.md
+++ b/SYKim_Doc/note_mapper_frontend_payloads.md
@@ -2,8 +2,8 @@
 
 | API/기능 | 최종 DTO | NoteMapper가 조립/추가하는 필드 | 비고 |
 |----------|---------|--------------------------------|------|
-| `GET /api/notes/published/today-detail` (구독자) <br> `GET /api/notes/archived/{id}` (`accessible=true`) | `NoteResponse` | `cover` 내부 `creatorName`, `creatorJobTitle`, `publishedDate` / `creatorId`, `creatorJobTitle` / `creator` summary / 타임스탬프 (`publishedAt`, `archivedAt`, `createdAt`, `updatedAt`) / `externalLink` | 노트 엔티티 + `Creator` 엔티티 + `NoteCover` 등 서브 엔티티 조합 |
-| `GET /api/notes/published/today-preview` <br> `GET /api/notes/archived/{id}` (`accessible=false`) | `NotePreviewResponse` | `cover`(title/mainImage/creator/publishedDate, **teaser=null**) + `overview`(`sectionTitle`, `bodyText`<=100자, `imageUrl`) | 상세 대신 프리뷰 전용 데이터를 구성 |
+| `GET /api/notes/published/today-detail` (구독자) <br> `GET /api/notes/archived/{id}` (`accessible=true`) | `NoteResponse` | `cover` 내부 `creatorName`, `creatorJobTitle`, `publishedDate`, `categoryBadge?` / `creatorId`, `creatorJobTitle` / `creator` summary / 타임스탬프 (`publishedAt`, `archivedAt`, `createdAt`, `updatedAt`) / `externalLink` | 노트 엔티티 + `Creator` 엔티티 + `NoteCover` 등 서브 엔티티 조합 |
+| `GET /api/notes/published/today-preview` <br> `GET /api/notes/archived/{id}` (`accessible=false`) | `NotePreviewResponse` | `cover`(title/mainImage/creator/publishedDate, `categoryBadge?`, **teaser=null**) + `overview`(`sectionTitle`, `bodyText`<=100자, `imageUrl`) | 상세 대신 프리뷰 전용 데이터를 구성 |
 | `GET /api/notes/published/today-cover` | `NoteCoverResponse` | `creatorName`, `creatorJobTitle`, `publishedDate` (노트·크리에이터 엔티티에서 조합) | 히어로 섹션 커버 UI |
 | `GET /api/notes/archived` | `ArchivedNoteSummaryResponse` | `title`, `mainImageUrl` (NoteCover), `creatorName`, `publishedDate` (note.publishedAt) | 카드 목록 전용 요약 DTO |
 | `GET /api/notes/bookmarks` | `BookmarkListItemResponse` (`NoteBookmarkResponse` → Mapper 변환) | `title`, `mainImageUrl` (NoteCover), `creatorName`, `tagText` (note.tagText) | Mapper가 `NoteBookmark` → `NoteBookmarkResponse`로 조립 후 컨트롤러에서 프론트 DTO로 변환 |
@@ -12,4 +12,6 @@
 ## 참고
 - `NoteMapper`는 `Note`, `Creator`, `NoteCover` 등 연관 엔티티를 조회해 DTO에 필요한 필드를 조립한다.
 - `NoteCoverDto`의 `creatorName`/`creatorJobTitle`은 **요청 시 optional**이며, Admin UI 미리보기용. 저장 시에는 `creatorId`만 사용하지만, 응답에서는 매퍼가 `Creator` 엔티티에서 다시 채워 넣는다.
+- `cover.categoryBadge`는 **today-preview / today-detail** API에서만 내려오며, 기타 API에는 포함되지 않는다.
+- `categoryBadge.type`는 기획에서 정의한 실 카테고리(`MURAL`, `EMOTICON`, `GRAPHIC`, `PRODUCT`, `FASHION`, `THREE_D`, `BRANDING`, `ILLUSTRATION`, `MEDIA_ART`, `FURNITURE`, `THEATER_SIGN`, `LANDSCAPE`, `ALBUM_ARTWORK`, `VISUAL_DIRECTING`, `NONE`) 중 하나다.
 - `ArchivedNoteViewResponse`는 `accessible` 플래그를 기준으로 `NoteResponse` 또는 `NotePreviewResponse` 중 하나를 채워 프론트가 단일 API 결과로 분기하도록 설계했다.

--- a/src/main/java/com/okebari/artbite/note/domain/NoteCategoryType.java
+++ b/src/main/java/com/okebari/artbite/note/domain/NoteCategoryType.java
@@ -1,0 +1,32 @@
+package com.okebari.artbite.note.domain;
+
+import lombok.Getter;
+
+/**
+ * 노트가 속한 카테고리를 나타내는 enum.
+ * 기획에서 사용 중인 실제 카테고리 명칭을 그대로 Enum 값으로 관리한다.
+ */
+@Getter
+public enum NoteCategoryType {
+	MURAL("벽화"),
+	EMOTICON("이모티콘"),
+	GRAPHIC("그래픽"),
+	PRODUCT("제품"),
+	FASHION("패션"),
+	THREE_D("3D"),
+	BRANDING("브랜딩"),
+	ILLUSTRATION("일러스트"),
+	MEDIA_ART("미디어아트"),
+	FURNITURE("가구"),
+	THEATER_SIGN("극장 손간판"),
+	LANDSCAPE("조경"),
+	ALBUM_ARTWORK("음반 아트워크"),
+	VISUAL_DIRECTING("비주얼 디렉팅"),
+	NONE("카테고리 없음");
+
+	private final String label;
+
+	NoteCategoryType(String label) {
+		this.label = label;
+	}
+}

--- a/src/main/java/com/okebari/artbite/note/domain/NoteCover.java
+++ b/src/main/java/com/okebari/artbite/note/domain/NoteCover.java
@@ -2,6 +2,8 @@ package com.okebari.artbite.note.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -37,11 +39,16 @@ public class NoteCover {
 	@Column(name = "main_image_url", nullable = false, length = 255)
 	private String mainImageUrl;
 
+	@Enumerated(EnumType.STRING)
+	@Column(name = "category", nullable = false, length = 30)
+	private NoteCategoryType category = NoteCategoryType.NONE;
+
 	@Builder
-	private NoteCover(String title, String teaser, String mainImageUrl) {
+	private NoteCover(String title, String teaser, String mainImageUrl, NoteCategoryType category) {
 		this.title = title;
 		this.teaser = teaser;
 		this.mainImageUrl = mainImageUrl;
+		this.category = category != null ? category : NoteCategoryType.NONE;
 	}
 
 	void bindNote(Note note) {

--- a/src/main/java/com/okebari/artbite/note/dto/note/CategoryBadgeResponse.java
+++ b/src/main/java/com/okebari/artbite/note/dto/note/CategoryBadgeResponse.java
@@ -1,0 +1,10 @@
+package com.okebari.artbite.note.dto.note;
+
+/**
+ * 노트 상세/미리보기에서 표시할 카테고리 배지 정보.
+ */
+public record CategoryBadgeResponse(
+	String type,
+	String label
+) {
+}

--- a/src/main/java/com/okebari/artbite/note/dto/note/NoteCoverDto.java
+++ b/src/main/java/com/okebari/artbite/note/dto/note/NoteCoverDto.java
@@ -1,5 +1,7 @@
 package com.okebari.artbite.note.dto.note;
 
+import com.okebari.artbite.note.domain.NoteCategoryType;
+
 import jakarta.validation.constraints.NotBlank;
 
 public record NoteCoverDto(
@@ -7,6 +9,7 @@ public record NoteCoverDto(
 	@NotBlank String teaser,
 	@NotBlank String mainImageUrl,
 	String creatorName,
-	String creatorJobTitle
+	String creatorJobTitle,
+	NoteCategoryType category
 ) {
 }

--- a/src/main/java/com/okebari/artbite/note/dto/note/NoteCoverResponse.java
+++ b/src/main/java/com/okebari/artbite/note/dto/note/NoteCoverResponse.java
@@ -2,16 +2,21 @@ package com.okebari.artbite.note.dto.note;
 
 import java.time.LocalDate;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
 /**
  * 노트 커버 영역을 프론트에 내려줄 때 사용하는 DTO.
  * 작성자 이름/직함과 게시 시각까지 포함해 히어로 섹션을 한 번에 구성한다.
  */
+@JsonInclude(Include.NON_NULL)
 public record NoteCoverResponse(
 	String title,
 	String teaser,
 	String mainImageUrl,
 	String creatorName,
 	String creatorJobTitle,
-	LocalDate publishedDate
+	LocalDate publishedDate,
+	CategoryBadgeResponse category
 ) {
 }

--- a/src/main/java/com/okebari/artbite/note/mapper/NoteMapper.java
+++ b/src/main/java/com/okebari/artbite/note/mapper/NoteMapper.java
@@ -12,6 +12,7 @@ import com.okebari.artbite.creator.mapper.CreatorMapper;
 import com.okebari.artbite.note.domain.Note;
 import com.okebari.artbite.note.domain.NoteAnswer;
 import com.okebari.artbite.note.domain.NoteBookmark;
+import com.okebari.artbite.note.domain.NoteCategoryType;
 import com.okebari.artbite.note.domain.NoteCover;
 import com.okebari.artbite.note.domain.NoteOverview;
 import com.okebari.artbite.note.domain.NoteProcess;
@@ -20,6 +21,7 @@ import com.okebari.artbite.note.domain.NoteRetrospect;
 import com.okebari.artbite.note.dto.answer.NoteAnswerDto;
 import com.okebari.artbite.note.dto.answer.NoteAnswerResponse;
 import com.okebari.artbite.note.dto.bookmark.NoteBookmarkResponse;
+import com.okebari.artbite.note.dto.note.CategoryBadgeResponse;
 import com.okebari.artbite.note.dto.note.NoteCoverDto;
 import com.okebari.artbite.note.dto.note.NoteCoverResponse;
 import com.okebari.artbite.note.dto.note.NoteCreateRequest;
@@ -70,6 +72,14 @@ public class NoteMapper {
 	// Note 엔티티를 단건 조회 응답 DTO로 변환한다.
 	// 질문·답변 등 하위 구성요소는 각각 전용 변환 메서드를 통해 조립한다.
 	public NoteResponse toResponse(Note note) {
+		return buildNoteResponse(note, false);
+	}
+
+	public NoteResponse toResponseWithCoverCategory(Note note) {
+		return buildNoteResponse(note, true);
+	}
+
+	private NoteResponse buildNoteResponse(Note note, boolean includeCategory) {
 		Creator creator = note.getCreator();
 		CreatorSummaryDto creatorSummary = creator != null ? creatorMapper.toSummary(creator) : null;
 		Long creatorId = creator != null ? creator.getId() : null;
@@ -82,7 +92,7 @@ public class NoteMapper {
 			note.getId(),
 			note.getStatus(),
 			note.getTagText(),
-			buildCoverResponse(note, false),
+			buildCoverResponse(note, false, includeCategory),
 			toOverviewDto(note.getOverview()),
 			toRetrospectDto(note.getRetrospect()),
 			note.getProcesses() != null
@@ -105,6 +115,14 @@ public class NoteMapper {
 
 	// 무료 사용자 미리보기 용도로 커버/요약 텍스트만 추린다.
 	public NotePreviewResponse toPreview(Note note, int overviewLimit) {
+		return buildPreview(note, overviewLimit, false);
+	}
+
+	public NotePreviewResponse toPreviewWithCategory(Note note, int overviewLimit) {
+		return buildPreview(note, overviewLimit, true);
+	}
+
+	private NotePreviewResponse buildPreview(Note note, int overviewLimit, boolean includeCategory) {
 		NoteOverviewDto overview = toOverviewDto(note.getOverview());
 		if (overview != null && overview.bodyText() != null && overview.bodyText().length() > overviewLimit) {
 			overview = new NoteOverviewDto(
@@ -116,7 +134,7 @@ public class NoteMapper {
 
 		return new NotePreviewResponse(
 			note.getId(),
-			buildCoverResponse(note, false),
+			buildCoverResponse(note, false, includeCategory),
 			overview
 		);
 	}
@@ -181,6 +199,7 @@ public class NoteMapper {
 			.title(dto.title())
 			.teaser(dto.teaser())
 			.mainImageUrl(dto.mainImageUrl())
+			.category(dto.category())
 			.build();
 	}
 
@@ -267,6 +286,10 @@ public class NoteMapper {
 	}
 
 	private NoteCoverResponse buildCoverResponse(Note note, boolean includeTeaser) {
+		return buildCoverResponse(note, includeTeaser, false);
+	}
+
+	private NoteCoverResponse buildCoverResponse(Note note, boolean includeTeaser, boolean includeCategory) {
 		NoteCover cover = note.getCover();
 		String creatorName = note.getCreator() != null ? note.getCreator().getName() : null;
 		String creatorJobTitle = note.getCreator() != null ? note.getCreator().getJobTitle() : null;
@@ -277,8 +300,20 @@ public class NoteMapper {
 			cover != null ? cover.getMainImageUrl() : null,
 			creatorName,
 			creatorJobTitle,
-			toDateOnly(note.getPublishedAt())
+			toDateOnly(note.getPublishedAt()),
+			includeCategory ? toCategoryBadge(cover) : null
 		);
+	}
+
+	private CategoryBadgeResponse toCategoryBadge(NoteCover cover) {
+		if (cover == null || cover.getCategory() == null) {
+			return null;
+		}
+		NoteCategoryType categoryType = cover.getCategory();
+		if (categoryType == NoteCategoryType.NONE) {
+			return null;
+		}
+		return new CategoryBadgeResponse(categoryType.name(), categoryType.getLabel());
 	}
 
 	private LocalDate toDateOnly(LocalDateTime dateTime) {

--- a/src/main/java/com/okebari/artbite/note/service/NoteQueryService.java
+++ b/src/main/java/com/okebari/artbite/note/service/NoteQueryService.java
@@ -44,7 +44,7 @@ public class NoteQueryService {
 	 */
 	public NotePreviewResponse getTodayPreview() {
 		Note note = findTodayPublishedNote();
-		return noteMapper.toPreview(note, OVERVIEW_PREVIEW_LIMIT);
+		return noteMapper.toPreviewWithCategory(note, OVERVIEW_PREVIEW_LIMIT);
 	}
 
 	/**
@@ -61,10 +61,10 @@ public class NoteQueryService {
 		Note note = findTodayPublishedNote();
 		boolean accessible = subscriptionService.isActiveSubscriber(userId);
 		if (!accessible) {
-			NotePreviewResponse preview = noteMapper.toPreview(note, OVERVIEW_PREVIEW_LIMIT);
+			NotePreviewResponse preview = noteMapper.toPreviewWithCategory(note, OVERVIEW_PREVIEW_LIMIT);
 			return new TodayPublishedResponse(false, null, preview);
 		}
-		return new TodayPublishedResponse(true, noteMapper.toResponse(note), null);
+		return new TodayPublishedResponse(true, noteMapper.toResponseWithCoverCategory(note), null);
 	}
 
 	/**

--- a/src/main/resources/db/migration/V8__add_category_to_note_cover.sql
+++ b/src/main/resources/db/migration/V8__add_category_to_note_cover.sql
@@ -1,0 +1,2 @@
+ALTER TABLE note_cover
+    ADD COLUMN category VARCHAR(30) DEFAULT 'NONE' NOT NULL;

--- a/src/test/java/com/okebari/artbite/note/service/NoteQueryServiceTest.java
+++ b/src/test/java/com/okebari/artbite/note/service/NoteQueryServiceTest.java
@@ -49,7 +49,7 @@ class NoteQueryServiceTest {
 
 		NoteOverviewDto overview = new NoteOverviewDto("섹션", "미리보기", null);
 		NotePreviewResponse preview = new NotePreviewResponse(1L, null, overview);
-		when(noteMapper.toPreview(note, 100)).thenReturn(preview);
+		when(noteMapper.toPreviewWithCategory(note, 100)).thenReturn(preview);
 
 		NotePreviewResponse result = noteQueryService.getTodayPreview();
 
@@ -79,7 +79,8 @@ class NoteQueryServiceTest {
 			"https://img",
 			"creator",
 			"jobTitle",
-			LocalDate.now()
+			LocalDate.now(),
+			null
 		);
 		when(noteMapper.toCoverResponse(note)).thenReturn(cover);
 
@@ -104,7 +105,7 @@ class NoteQueryServiceTest {
 		when(noteRepository.findFirstByStatusAndPublishedAtBetween(eq(NoteStatus.PUBLISHED), any(), any()))
 			.thenReturn(java.util.Optional.of(note));
 		NoteResponse response = mock(NoteResponse.class);
-		when(noteMapper.toResponse(note)).thenReturn(response);
+		when(noteMapper.toResponseWithCoverCategory(note)).thenReturn(response);
 
 		TodayPublishedResponse result = noteQueryService.getTodayPublishedDetail(1L);
 
@@ -121,7 +122,7 @@ class NoteQueryServiceTest {
 			.thenReturn(java.util.Optional.of(note));
 		NoteOverviewDto overview2 = new NoteOverviewDto("섹션", "preview", null);
 		NotePreviewResponse preview = new NotePreviewResponse(1L, null, overview2);
-		when(noteMapper.toPreview(note, 100)).thenReturn(preview);
+		when(noteMapper.toPreviewWithCategory(note, 100)).thenReturn(preview);
 
 		TodayPublishedResponse result = noteQueryService.getTodayPublishedDetail(2L);
 

--- a/src/test/java/com/okebari/artbite/note/service/NoteServiceTest.java
+++ b/src/test/java/com/okebari/artbite/note/service/NoteServiceTest.java
@@ -167,7 +167,7 @@ class NoteServiceTest {
 		return new NoteCreateRequest(
 			status,
 			"tag",
-			new NoteCoverDto("title", "teaser", "https://img.main", null, null),
+			new NoteCoverDto("title", "teaser", "https://img.main", null, null, null),
 			new NoteOverviewDto("overview", "overview body", "https://img.overview"),
 			new NoteRetrospectDto("retro", "retro body"),
 			List.of(
@@ -184,7 +184,7 @@ class NoteServiceTest {
 		return new NoteUpdateRequest(
 			status,
 			"tag",
-			new NoteCoverDto("title", "teaser", "https://img.main", null, null),
+			new NoteCoverDto("title", "teaser", "https://img.main", null, null, null),
 			new NoteOverviewDto("overview", "overview body", "https://img.overview"),
 			new NoteRetrospectDto("retro", "retro body"),
 			List.of(


### PR DESCRIPTION
> 제목은 `[#3 ] feat: 카테고리 항목 추가

## 관련 이슈
- 메인 이슈: #카테고리배지-노출
- 서브 이슈: #today-preview-카테고리, #today-detail-카테고리

## 변경 사항
> (무엇을) 어떻게 바꿨는지 구체적으로 작성
- NoteCover에 실제 카테고리 enum(벽화, 이모티콘 등 15종) 필드 추가 및 DB 컬럼/마이그레이션 반영
- today-preview · today-detail 응답에서만 `cover.categoryBadge`를 내려주도록 NoteMapper/NoteQueryService 경로 분리
- Admin 요청 DTO, 프론트 타입 정의, 문서에 카테고리 필드/배지 노출 규칙 추가

## 변경 이유
> 왜 이 변경이 필요한지 설명
- 무료/유료 상세 화면에서 작품 카테고리를 배지 형태로 노출해 사용자가 콘텐츠 성격을 빠르게 인지할 수 있게 하기 위해서

## 테스트
> 어떤 방법으로 검증했는지 작성
- ./gradlew test

## 참고 자료 (선택)
- [설계 문서](SYKim_Doc/note_cover_dto_change_summary.md#61-카테고리-노출-흐름)
- [관련 기술 자료](SYKim_Doc/frontend_payload_review.md)

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
- today-preview/detail 외 API에서 배지가 노출되지 않는지 Mapper 분기 로직 확인 부탁드립니다.

## PR 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 예외 케이스 처리 완료
- [ ] Swagger / API 문서 반영 완료
