### PR TITLE
[#3]refactor: url varchar size alter(#33)

### DIFF
--- a/SYKim_Doc/ERD.md
+++ b/SYKim_Doc/ERD.md
@@ -38,13 +38,13 @@
 | `name` | VARCHAR(60) | NOT NULL |
 | `bio` | VARCHAR(100) | 작가 소개 |
 | `job_title` | VARCHAR(60) | 직위/직함 (작가 소개와 별개 항목) |
-| `profile_image_url` | VARCHAR(255) | 작가 프로필 이미지 URL |
-| `instagram_url` | VARCHAR(255) | 선택 |
-| `youtube_url` | VARCHAR(255) | 선택 |
-| `behance_url` | VARCHAR(255) | 선택 |
-| `x_url` | VARCHAR(255) | 선택 |
-| `blog_url` | VARCHAR(255) | 선택 |
-| `news_url` | VARCHAR(255) | 선택 |
+| `profile_image_url` | VARCHAR(500) | 작가 프로필 이미지 URL |
+| `instagram_url` | VARCHAR(500) | 선택 |
+| `youtube_url` | VARCHAR(500) | 선택 |
+| `behance_url` | VARCHAR(500) | 선택 |
+| `x_url` | VARCHAR(500) | 선택 |
+| `blog_url` | VARCHAR(500) | 선택 |
+| `news_url` | VARCHAR(500) | 선택 |
 
 > [2025-11-05] `job_title`과 `bio`를 별도 컬럼으로 명시하고 `profile_image_url` 컬럼 정의를 추가했습니다. `notes_head.creator_id` 설명도 애플리케이션 검증 조건에 맞게 조정했습니다.
 
@@ -69,7 +69,8 @@
 | `note_id` | BIGINT | PK, FK → `notes_head.id`, `ON DELETE CASCADE` |
 | `title` | VARCHAR(30) | NOT NULL |
 | `teaser` | VARCHAR(100) | NOT NULL |
-| `main_image_url` | VARCHAR(255) | NOT NULL |
+| `main_image_url` | VARCHAR(500) | NOT NULL |
+| `category` | VARCHAR(30) | NOT NULL, enum(`MURAL`,`EMOTICON`,`GRAPHIC`,`PRODUCT`,`FASHION`,`THREE_D`,`BRANDING`,`ILLUSTRATION`,`MEDIA_ART`,`FURNITURE`,`THEATER_SIGN`,`LANDSCAPE`,`ALBUM_ARTWORK`,`VISUAL_DIRECTING`,`NONE`), 기본값 `NONE` |
 | *(cardinality)* |  | 한 노트당 정확히 1행 유지 |
 
 ## note_overview (`NOTE_OVERVIEW`)
@@ -79,7 +80,7 @@
 | `note_id` | BIGINT | PK, FK → `notes_head.id`, `ON DELETE CASCADE` |
 | `section_title` | VARCHAR(30) | NOT NULL |
 | `body_text` | VARCHAR(200) | NOT NULL |
-| `image_url` | VARCHAR(255) | NOT NULL |
+| `image_url` | VARCHAR(500) | NOT NULL |
 | *(cardinality)* |  | 한 노트당 정확히 1행 유지 |
 
 ## note_process (`NOTE_PROCESS`)
@@ -90,7 +91,7 @@
 | `position` | SMALLINT | PK 구성, 1 또는 2 (`CHECK`) |
 | `section_title` | VARCHAR(30) | NOT NULL |
 | `body_text` | VARCHAR(500) | NOT NULL |
-| `image_url` | VARCHAR(255) | NOT NULL |
+| `image_url` | VARCHAR(500) | NOT NULL |
 | *(cardinality)* |  | 한 노트당 정확히 2행 (position 1,2) |
 
 ## note_retrospect (`NOTE_RETROSPECT`)
@@ -144,7 +145,7 @@
 | `source_type` | VARCHAR(30) | NOT NULL, enum(`BOOKMARK`, `ANSWER`) |
 | `payload_note_id` | BIGINT | 캐시 스냅샷용 note_id (보조 필드) |
 | `payload_title` | VARCHAR(60) | 배너에 노출할 노트 제목 |
-| `payload_main_image_url` | VARCHAR(255) | 배너 썸네일 |
+| `payload_main_image_url` | VARCHAR(500) | 배너 썸네일 |
 | `first_visit_at` | TIMESTAMP WITH TIME ZONE | 당일 첫 방문 시각 |
 | `banner_seen_at` | TIMESTAMP WITH TIME ZONE | 배너가 실제 노출된 시각(두 번째 방문) |
 | `modal_closed_at` | TIMESTAMP WITH TIME ZONE | X 모달에서 “취소” 선택 시각 |

--- a/src/main/java/com/okebari/artbite/creator/domain/Creator.java
+++ b/src/main/java/com/okebari/artbite/creator/domain/Creator.java
@@ -35,25 +35,25 @@ public class Creator {
 	@Column(name = "job_title", length = 60)
 	private String jobTitle;
 
-	@Column(name = "profile_image_url", length = 255)
+	@Column(name = "profile_image_url", length = 500)
 	private String profileImageUrl;
 
-	@Column(name = "instagram_url", length = 255)
+	@Column(name = "instagram_url", length = 500)
 	private String instagramUrl;
 
-	@Column(name = "youtube_url", length = 255)
+	@Column(name = "youtube_url", length = 500)
 	private String youtubeUrl;
 
-	@Column(name = "behance_url", length = 255)
+	@Column(name = "behance_url", length = 500)
 	private String behanceUrl;
 
-	@Column(name = "x_url", length = 255)
+	@Column(name = "x_url", length = 500)
 	private String xUrl;
 
-	@Column(name = "blog_url", length = 255)
+	@Column(name = "blog_url", length = 500)
 	private String blogUrl;
 
-	@Column(name = "news_url", length = 255)
+	@Column(name = "news_url", length = 500)
 	private String newsUrl;
 
 	@Builder

--- a/src/main/java/com/okebari/artbite/note/domain/NoteCover.java
+++ b/src/main/java/com/okebari/artbite/note/domain/NoteCover.java
@@ -36,7 +36,7 @@ public class NoteCover {
 	@Column(nullable = false, length = 100)
 	private String teaser;
 
-	@Column(name = "main_image_url", nullable = false, length = 255)
+	@Column(name = "main_image_url", nullable = false, length = 500)
 	private String mainImageUrl;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/okebari/artbite/note/domain/NoteOverview.java
+++ b/src/main/java/com/okebari/artbite/note/domain/NoteOverview.java
@@ -34,7 +34,7 @@ public class NoteOverview {
 	@Column(nullable = false, length = 200)
 	private String bodyText;
 
-	@Column(nullable = false, length = 255)
+	@Column(nullable = false, length = 500)
 	private String imageUrl;
 
 	@Builder

--- a/src/main/java/com/okebari/artbite/note/domain/NoteProcess.java
+++ b/src/main/java/com/okebari/artbite/note/domain/NoteProcess.java
@@ -34,7 +34,7 @@ public class NoteProcess {
 	@Column(name = "body_text", nullable = false, length = 500)
 	private String bodyText;
 
-	@Column(name = "image_url", nullable = false, length = 255)
+	@Column(name = "image_url", nullable = false, length = 500)
 	private String imageUrl;
 
 	@Builder

--- a/src/main/java/com/okebari/artbite/note/domain/NoteReminderPayload.java
+++ b/src/main/java/com/okebari/artbite/note/domain/NoteReminderPayload.java
@@ -22,7 +22,7 @@ public class NoteReminderPayload {
 	@Column(name = "payload_title", length = 60)
 	private String title;
 
-	@Column(name = "payload_main_image_url", length = 255)
+	@Column(name = "payload_main_image_url", length = 500)
 	private String mainImageUrl;
 
 	public NoteReminderPayload copyWithNoteId(Long noteId) {

--- a/src/main/resources/db/migration/V10__extend_image_url_columns.sql
+++ b/src/main/resources/db/migration/V10__extend_image_url_columns.sql
@@ -1,0 +1,11 @@
+ALTER TABLE note_cover
+    ALTER COLUMN main_image_url TYPE VARCHAR(500);
+
+ALTER TABLE note_overview
+    ALTER COLUMN image_url TYPE VARCHAR(500);
+
+ALTER TABLE note_process
+    ALTER COLUMN image_url TYPE VARCHAR(500);
+
+ALTER TABLE note_reminder_pot
+    ALTER COLUMN payload_main_image_url TYPE VARCHAR(500);

--- a/src/main/resources/db/migration/V9__extend_creator_url_columns.sql
+++ b/src/main/resources/db/migration/V9__extend_creator_url_columns.sql
@@ -1,0 +1,23 @@
+ALTER TABLE note_creator
+    ADD COLUMN IF NOT EXISTS profile_image_url VARCHAR(500);
+
+ALTER TABLE note_creator
+    ALTER COLUMN profile_image_url TYPE VARCHAR(500);
+
+ALTER TABLE note_creator
+    ALTER COLUMN instagram_url TYPE VARCHAR(500);
+
+ALTER TABLE note_creator
+    ALTER COLUMN youtube_url TYPE VARCHAR(500);
+
+ALTER TABLE note_creator
+    ALTER COLUMN behance_url TYPE VARCHAR(500);
+
+ALTER TABLE note_creator
+    ALTER COLUMN x_url TYPE VARCHAR(500);
+
+ALTER TABLE note_creator
+    ALTER COLUMN blog_url TYPE VARCHAR(500);
+
+ALTER TABLE note_creator
+    ALTER COLUMN news_url TYPE VARCHAR(500);


### PR DESCRIPTION
> 제목은 `[#3] refactor: url varchar size 255 -> 변경 

## 관련 이슈
- 메인 이슈: #이미지URL-길이확장
- 서브 이슈: #reminder-payload-url, #creator-thumbnail-url

## 변경 사항
> (무엇을) 어떻게 바꿨는지 구체적으로 작성
- note_cover.main_image_url, note_overview.image_url, note_process.image_url, note_reminder_pot.payload_main_image_url을 VARCHAR(500)으로 확장하고 엔티티/DTO 매핑을 모두 500자로 맞춤
- Creator SNS/프로필 URL 컬럼 역시 VARCHAR(500)으로 확장하며, 엔티티와 ERD 문서를 최신화
- Flyway 스크립트(V9, V10) 추가로 위 컬럼 타입이 실제 DB에서도 ALTER 되도록 처리

## 변경 이유
> 왜 이 변경이 필요한지 설명
- 외부 CDN/이미지 경로가 255자를 초과하는 경우가 잦아 저장/응답 시 오류가 발생했기 때문에, 여유 길이(500자)로 확장해 안정적으로 값을 보관하기 위함

## 테스트
> 어떤 방법으로 검증했는지 작성
- ./gradlew test

## 참고 자료 (선택)
- [설계 문서](SYKim_Doc/ERD.md)
- [관련 기술 자료](SYKim_Doc/note_creator_api_spec.md)

## 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성
- 최신 DB 스키마(RDM 또는 DBA 적용)에서 VARCHAR 길이 확장이 실제로 반영되는지 확인 부탁드립니다.

## PR 체크리스트
- [x] 빌드 및 테스트 통과
- [x] 코드 컨벤션 준수
- [x] 예외 케이스 처리 완료
- [ ] Swagger / API 문서 반영 완료
